### PR TITLE
Fix zopen read for json in python<3.6

### DIFF
--- a/monty/serialization.py
+++ b/monty/serialization.py
@@ -71,7 +71,7 @@ def loadfn(fn, *args, **kwargs):
         with zopen(fn, "rb") as fp:
             return msgpack.load(fp, *args, **kwargs)
     else:
-        with zopen(fn) as fp:
+        with zopen(fn, 'rt') as fp:
             if any(ext in os.path.basename(fn).lower()
                    for ext in (".yaml", ".yml")):
                 if yaml is None:


### PR DESCRIPTION
The `json` package in python<3.6 doesn't support binary strings for `loads()`, so changed reading in `loadfn()` to `'rt'` to read as text instead of binary.